### PR TITLE
Add api handler for upcoming episodes

### DIFF
--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -13,6 +13,12 @@ import (
 	"github.com/swayne275/gerrors"
 )
 
+/*
+TODO
+- standardize error format as JSON
+- endpoint for searching by string, returning basic show structs as response
+*/
+
 const serverPort = "8080"
 
 type showID struct {
@@ -48,7 +54,21 @@ func getUpcomingEpisodes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tvshowdata.GetShowData(id.ID)
+	haveEpisodes, episodes := tvshowdata.GetShowData(id.ID)
+	if haveEpisodes {
+		output, err := json.Marshal(episodes)
+		if err != nil {
+			msg := "Unable to process upcoming shows"
+			err = gerrors.Wrapf(err, msg)
+			fmt.Println(err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		w.Write(output)
+	} else {
+		http.Error(w, "No upcoming episodes", http.StatusNotFound)
+	}
 }
 
 // StartClientAPI starts the web server hosting the client API

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -3,11 +3,21 @@
 package clientapi
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"showcal-backend-go/tvshowdata"
 	"strings"
+
+	"github.com/swayne275/gerrors"
 )
 
-var serverPort = "8080"
+const serverPort = "8080"
+
+type showID struct {
+	ID int64 `json:"id"`
+}
 
 func sayHello(w http.ResponseWriter, r *http.Request) {
 	message := r.URL.Path
@@ -17,10 +27,39 @@ func sayHello(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(message))
 }
 
-// StartClientAPI starts the web server hosting the client API
-func StartClientAPI() {
-	http.HandleFunc("/", sayHello)
-	if err := http.ListenAndServe(":"+serverPort, nil); err != nil {
-		panic(err)
+func getUpcomingEpisodes(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		msg := "Unable to get query ID from getUpcomingEpisodes body"
+		err = gerrors.Wrapf(err, msg)
+		fmt.Println(err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
+
+	var id showID
+	err = json.Unmarshal(body, &id)
+	if err != nil {
+		msg := "Unable to parse show ID from request body"
+		err = gerrors.Wrapf(err, msg)
+		fmt.Println(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	tvshowdata.GetShowData(id.ID)
+}
+
+// StartClientAPI starts the web server hosting the client API
+func StartClientAPI() error {
+	http.HandleFunc("/", sayHello)
+	http.HandleFunc("/upcomingepisodes", getUpcomingEpisodes)
+	if err := http.ListenAndServe(":"+serverPort, nil); err != nil {
+		msg := fmt.Sprintf("Could not start client API server on port %s", serverPort)
+		err = gerrors.Wrapf(err, msg)
+		return err
+	}
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	webserver "showcal-backend-go/clientapi"
-	tvshowdata "showcal-backend-go/tvshowdata"
 )
 
 func main() {
 	//const queryID = 33514 // The 100
 	//const queryID = 2550 // American Dad
-	const queryID = 3564 // Friends
+	//const queryID = 3564 // Friends
 
-	tvshowdata.GetShowData(queryID)
 	webserver.StartClientAPI()
 }

--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -90,7 +90,7 @@ func reformatShowDate(json gjson.Result) (time.Time, error) {
 }
 
 // Determine if there are likely future episodes of a show or not
-func checkForFutureEpisodes(showData string, ID int) (bool, error) {
+func checkForFutureEpisodes(showData string, ID int64) (bool, error) {
 	countdown := gjson.Get(showData, "tvShow.countdown")
 	if !countdown.Exists() {
 		msg := fmt.Sprintf("api returned invalid countdown data for queryID: %d", ID)
@@ -140,7 +140,7 @@ func parseUpcomingEpisodes(showData string) (UpcomingEpisodes, error) {
 }
 
 // Get a list of upcoming shows for a particular Episodate query ID
-func getUpcomingShows(queryID int) (UpcomingEpisodes, error) {
+func getUpcomingShows(queryID int64) (UpcomingEpisodes, error) {
 	url := fmt.Sprintf("https://episodate.com/api/show-details?q=%d", queryID)
 	resp, err := httpGet(url)
 	if err != nil {
@@ -171,7 +171,7 @@ and save everything from then on to add to the calendar
 */
 
 // GetShowData gets the air times of upcoming episodes for the given queryID
-func GetShowData(queryID int) {
+func GetShowData(queryID int64) {
 	episodeList, err := getUpcomingShows(queryID)
 	if err != nil {
 		fmt.Println("Error getting the show data:", err)

--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -16,12 +16,13 @@ import (
 )
 
 // Episode represents an upcoming episode of a TV show
+// Not using struct tags for casing consistency upon json.Marshal
+// Would be nice if this was supported: AirDate time.Time `time:"2006-01-02 15:04:05"`
 type Episode struct {
-	Season  float64   `json:"season"`
-	Episode float64   `json:"episode"`
-	Name    string    `json:"name"`
+	Season  float64   //`json:"season"`
+	Episode float64   //`json:"episode"`
+	Name    string    //`json:"name"`
 	AirDate time.Time // can't put struct tag due to non RFC 3339 format
-	//AirDate time.Time `time:"2006-01-02 15:04:05"` // format doesn't work for unmarshall
 }
 
 // UpcomingEpisodes is the list of Episodes for the show
@@ -164,26 +165,13 @@ func getUpcomingShows(queryID int64) (UpcomingEpisodes, error) {
 	return parseUpcomingEpisodes(resp)
 }
 
-/*
-TODO check if the show has a null value for "countdown". If so, there's
-not a known next episode, and it cannot be added to the calendar. If there
-is one, we need to look through the episode data to find the next episode,
-and save everything from then on to add to the calendar
-*/
-
 // GetShowData gets the air times of upcoming episodes for the given queryID
-func GetShowData(queryID int64) {
+func GetShowData(queryID int64) (bool, UpcomingEpisodes) {
 	episodeList, err := getUpcomingShows(queryID)
 	if err != nil {
 		fmt.Println("Error getting the show data:", err)
-		return
+		return false, UpcomingEpisodes{}
 	}
 
-	if len(episodeList.Episodes) > 0 {
-		for _, episode := range episodeList.Episodes {
-			fmt.Printf("%+v\n", episode)
-		}
-	} else {
-		fmt.Println("No future episodes for show ID", queryID)
-	}
+	return (len(episodeList.Episodes) > 0), episodeList
 }

--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -17,10 +17,11 @@ import (
 
 // Episode represents an upcoming episode of a TV show
 type Episode struct {
-	Season  float64
-	Episode float64
-	Name    string
-	AirDate time.Time
+	Season  float64   `json:"season"`
+	Episode float64   `json:"episode"`
+	Name    string    `json:"name"`
+	AirDate time.Time // can't put struct tag due to non RFC 3339 format
+	//AirDate time.Time `time:"2006-01-02 15:04:05"` // format doesn't work for unmarshall
 }
 
 // UpcomingEpisodes is the list of Episodes for the show


### PR DESCRIPTION
API handler to take a query ID as input and return a list of upcoming episodes for that show (if there are any)

Also experimented with struct tags for json marshal/unmarshal, but stopped using them for casing consistency (golang public members must start w a capital and golang doesn't like snake case, but Episodate does both of these things). Also tried using a tag with `time` or `layout` to auto format a non RFC 3339 time (from episodate) and eliminate my parse function, but it didn't work