### PR TITLE
Get TV Show runtime, show name for better calendar integration

### DIFF
--- a/gcalwrapper/gcalwrapper.go
+++ b/gcalwrapper/gcalwrapper.go
@@ -169,19 +169,16 @@ func buildCalendarEvent(event BasicEvent) (calendar.Event, error) {
 	return gcalEvent, nil
 }
 
-// TODO add show name to episode struct
-// TODO get run time of show
-
 // formatEpisodeForCalendar converts a TV show episode into a calendar event
 func formatEpisodeForCalendar(episode tvshowdata.Episode) BasicEvent {
-	summary := fmt.Sprintf("[show]: %s", episode.Title)
-	description := fmt.Sprintf("[show] \"%s\": Season %d, Episode %d",
-		episode.Title, episode.Season, episode.Episode)
+	summary := fmt.Sprintf("%s: \"%s\"", episode.ShowName, episode.Title)
+	description := fmt.Sprintf("%s: \"%s\"\nSeason %d, Episode %d",
+		episode.ShowName, episode.Title, episode.Season, episode.Episode)
 	event := BasicEvent{
 		Summary:     summary,
 		Description: description,
 		Start:       episode.AirDate.Time,
-		End:         episode.AirDate.Time.Add(time.Hour * time.Duration(1)),
+		End:         episode.AirDate.Time.Add(time.Minute * time.Duration(episode.RuntimeMinutes)),
 	}
 
 	return event


### PR DESCRIPTION
- get the show runtime for proper length events in calendar entry
- propagate show name with Episode for nice calendar entries
- better client api JSON formatting
- cleanup

Note: in one place I return an error if given an invalid runtime, in another i default it to 30 minutes. I'm not sure which I prefer. Runtime isn't mission-critical, but I do want the error to be known