### PR TITLE
Add more tests for tvshowdata pkg, fix code based on tests

### DIFF
--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -225,6 +225,11 @@ func checkForFutureEpisodes(showData string, ID int64) (bool, error) {
 // Unmarshals any shows matching the query to appropriate format
 func parseCandidateShows(queryData string) (Shows, error) {
 	allCandidates := gjson.Get(queryData, "tv_shows")
+	if !allCandidates.Exists() {
+		return Shows{}, gerrors.New("No 'tv_shows' field in API response")
+	}
+
+	// TODO runtime isn't included in this data
 	runtimeValue := gjson.Get(queryData, "runtime")
 	var runtime int64
 	if !runtimeValue.Exists() || runtimeValue.Int() == 0 {
@@ -245,6 +250,10 @@ func parseCandidateShows(queryData string) (Shows, error) {
 			msg := "Could not unmarshal show from API"
 			err = gerrors.Wrapf(err, msg)
 			// stop iterating
+			return false
+		}
+		if show == (Show{}) {
+			err = gerrors.New(fmt.Sprintf("Couldn't parse show data for: '%s'", value.String()))
 			return false
 		}
 

--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -57,10 +57,9 @@ type Episodes struct {
 
 // Show is the basic show details, and if it is still running
 type Show struct {
-	Name           string  `json:"name"`
-	ID             int64   `json:"id"`
-	RuntimeMinutes int64   `json:"runtime"`
-	StillRunning   Running `json:"status"`
+	Name         string  `json:"name"`
+	ID           int64   `json:"id"`
+	StillRunning Running `json:"status"`
 }
 
 // Shows is the list of candidate Shows for the query
@@ -229,16 +228,6 @@ func parseCandidateShows(queryData string) (Shows, error) {
 		return Shows{}, gerrors.New("No 'tv_shows' field in API response")
 	}
 
-	// TODO runtime isn't included in this data
-	runtimeValue := gjson.Get(queryData, "runtime")
-	var runtime int64
-	if !runtimeValue.Exists() || runtimeValue.Int() == 0 {
-		// default to a 30 minute runtime if not given
-		runtime = 30
-	} else {
-		runtime = runtimeValue.Int()
-	}
-
 	// declare error here to preserve any error from the ForEach loop
 	var err error
 	candidateShows := Shows{}
@@ -256,8 +245,6 @@ func parseCandidateShows(queryData string) (Shows, error) {
 			err = gerrors.New(fmt.Sprintf("Couldn't parse show data for: '%s'", value.String()))
 			return false
 		}
-
-		show.RuntimeMinutes = runtime
 		candidateShows.Shows = append(candidateShows.Shows, show)
 
 		// keep iterating

--- a/tvshowdata/tvshowdata.go
+++ b/tvshowdata/tvshowdata.go
@@ -169,8 +169,9 @@ func httpGet(url string) (string, error) {
 
 // Determines if there are any shows matching query from the API
 func checkForCandidateShows(queryData, query string) (bool, error) {
-	total := gjson.Get(queryData, "total")
 	msg := fmt.Sprintf("error getting total shows for query '%s'", query)
+	total := gjson.Get(queryData, "total")
+
 	if !total.Exists() {
 		err := gerrors.Wrapf(gerrors.New("missing 'total'"), msg)
 		return false, err

--- a/tvshowdata/tvshowdata_test.go
+++ b/tvshowdata/tvshowdata_test.go
@@ -244,3 +244,67 @@ func TestCheckForFutureEpisodes(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCandidateShows(t *testing.T) {
+	cases := []struct {
+		name        string
+		inData      string
+		expectedOut Shows
+		expectErr   bool
+	}{
+		{
+			name:   "good data, two shows",
+			inData: "{\"total\":\"1\",\"page\":1,\"pages\":1,\"tv_shows\":[{\"id\":2550,\"name\":\"American Dad!\",\"permalink\":\"american-dad\",\"start_date\":\"2005-02-06\",\"end_date\":null,\"country\":\"US\",\"network\":\"TBS\",\"status\":\"Running\",\"image_thumbnail_path\":\"https://static.episodate.com/images/tv-show/thumbnail/2550.jpg\"},{\"id\":25501,\"name\":\"American Dad1!\",\"permalink\":\"american-dad\",\"start_date\":\"2005-02-06\",\"end_date\":null,\"country\":\"US\",\"network\":\"TBS\",\"status\":\"Running\",\"image_thumbnail_path\":\"https://static.episodate.com/images/tv-show/thumbnail/2550.jpg\"}]}",
+			expectedOut: Shows{[]Show{
+				Show{
+					Name:           "American Dad!",
+					ID:             2550,
+					RuntimeMinutes: 30,
+					StillRunning:   Running{true},
+				},
+				Show{
+					Name:           "American Dad1!",
+					ID:             25501,
+					RuntimeMinutes: 30,
+					StillRunning:   Running{true},
+				},
+			}},
+			expectErr: false,
+		},
+		{
+			name:        "missing tv_shows",
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":1}",
+			expectedOut: Shows{},
+			expectErr:   true,
+		},
+		{
+			name:        "incorrect show format",
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":1,\"tv_shows\":[{\"s1\":2550,\"s2\":\"American Dad!\",\"s3\":\"Running\"}]}",
+			expectedOut: Shows{},
+			expectErr:   true,
+		},
+		{
+			name:        "bad show data",
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":1,\"tv_shows\":[{hello}]}",
+			expectedOut: Shows{},
+			expectErr:   true,
+		},
+	}
+
+	for _, c := range cases {
+		out, err := parseCandidateShows(c.inData)
+		gotErr := (err != nil)
+
+		if gotErr != c.expectErr {
+			t.Errorf("incorrect output error for '%s': expected '%t', got '%t'",
+				c.name, c.expectErr, gotErr)
+		}
+
+		for idx, show := range c.expectedOut.Shows {
+			if out.Shows[idx] != show {
+				t.Errorf("incorrect output for '%s': expected '%+v', got '%+v'",
+					c.name, show, out.Shows[idx])
+			}
+		}
+	}
+}

--- a/tvshowdata/tvshowdata_test.go
+++ b/tvshowdata/tvshowdata_test.go
@@ -257,16 +257,14 @@ func TestParseCandidateShows(t *testing.T) {
 			inData: "{\"total\":\"1\",\"page\":1,\"pages\":1,\"tv_shows\":[{\"id\":2550,\"name\":\"American Dad!\",\"permalink\":\"american-dad\",\"start_date\":\"2005-02-06\",\"end_date\":null,\"country\":\"US\",\"network\":\"TBS\",\"status\":\"Running\",\"image_thumbnail_path\":\"https://static.episodate.com/images/tv-show/thumbnail/2550.jpg\"},{\"id\":25501,\"name\":\"American Dad1!\",\"permalink\":\"american-dad\",\"start_date\":\"2005-02-06\",\"end_date\":null,\"country\":\"US\",\"network\":\"TBS\",\"status\":\"Running\",\"image_thumbnail_path\":\"https://static.episodate.com/images/tv-show/thumbnail/2550.jpg\"}]}",
 			expectedOut: Shows{[]Show{
 				Show{
-					Name:           "American Dad!",
-					ID:             2550,
-					RuntimeMinutes: 30,
-					StillRunning:   Running{true},
+					Name:         "American Dad!",
+					ID:           2550,
+					StillRunning: Running{true},
 				},
 				Show{
-					Name:           "American Dad1!",
-					ID:             25501,
-					RuntimeMinutes: 30,
-					StillRunning:   Running{true},
+					Name:         "American Dad1!",
+					ID:           25501,
+					StillRunning: Running{true},
 				},
 			}},
 			expectErr: false,

--- a/tvshowdata/tvshowdata_test.go
+++ b/tvshowdata/tvshowdata_test.go
@@ -197,3 +197,50 @@ func TestCheckForCandidateShows(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckForFutureEpisodes(t *testing.T) {
+	cases := []struct {
+		name        string
+		inData      string
+		inQuery     int64
+		expectedOut bool
+		expectedErr bool
+	}{
+		{
+			name:        "2550 good data",
+			inData:      "{\"tvShow\":{\"id\":2550,\"name\":\"American Dad!\",\"countdown\":{\"season\":15,\"episode\":20,\"name\":\"The Hand that Rocks the Rogu\",\"air_date\":\"2119-08-27 02:00:00\"}}}",
+			inQuery:     2550,
+			expectedOut: true,
+			expectedErr: false,
+		},
+		{
+			name:        "2550 missing object",
+			inData:      "{\"tvShow\":{\"id\":2550,\"name\":\"American Dad!\"}}",
+			inQuery:     2550,
+			expectedOut: false,
+			expectedErr: true,
+		},
+		{
+			name:        "2550 null object",
+			inData:      "{\"tvShow\":{\"id\":2550,\"name\":\"American Dad!\",\"countdown\":null}}",
+			inQuery:     2550,
+			expectedOut: false,
+			expectedErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		out, err := checkForFutureEpisodes(c.inData, c.inQuery)
+		gotErr := (err != nil)
+
+		if gotErr != c.expectedErr {
+			t.Errorf("incorrect output error for '%s': expected '%t', got '%t'",
+				c.name, c.expectedErr, gotErr)
+		}
+
+		if out != c.expectedOut {
+			t.Errorf("incorrect output error for '%s': expected '%t', got '%t'",
+				c.name, c.expectedErr, gotErr)
+		}
+	}
+}

--- a/tvshowdata/tvshowdata_test.go
+++ b/tvshowdata/tvshowdata_test.go
@@ -130,3 +130,70 @@ func TestGetShowURLs(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckForCandidateShows(t *testing.T) {
+	cases := []struct {
+		inData      string
+		inQuery     string
+		expectedOut bool
+		expectErr   bool
+	}{
+		{
+			inData:      "{\"page\":1,\"pages\":0,\"tv_shows\":[]}",
+			inQuery:     "nototal",
+			expectedOut: false,
+			expectErr:   true,
+		},
+		{
+			inData:      "{\"total\":0,\"page\":1,\"pages\":0,\"tv_shows\":[]}",
+			inQuery:     "badtotal-type",
+			expectedOut: false,
+			expectErr:   true,
+		},
+		{
+			inData:      "{\"total\":\"hello\",\"page\":1,\"pages\":0,\"tv_shows\":[]}",
+			inQuery:     "badtotal-value",
+			expectedOut: false,
+			expectErr:   true,
+		},
+		{
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":0}",
+			inQuery:     "noshows-missing",
+			expectedOut: false,
+			expectErr:   true,
+		},
+		{
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":0,\"tv_shows\":\"hello\"}",
+			inQuery:     "noshows-type",
+			expectedOut: false,
+			expectErr:   true,
+		},
+		{
+			inData:      "{\"total\":\"0\",\"page\":1,\"pages\":0,\"tv_shows\":[]}",
+			inQuery:     "somerandomjunk",
+			expectedOut: false,
+			expectErr:   false,
+		},
+		{
+			inData:      "{\"total\":\"1\",\"page\":1,\"pages\":1,\"tv_shows\":[{\"id\":2550,\"name\":\"American Dad!\",\"permalink\":\"american-dad\",\"start_date\":\"2005-02-06\",\"end_date\":null,\"country\":\"US\",\"network\":\"TBS\",\"status\":\"Running\",\"image_thumbnail_path\":\"https://static.episodate.com/images/tv-show/thumbnail/2550.jpg\"}]}",
+			inQuery:     "American Dad",
+			expectedOut: true,
+			expectErr:   false,
+		},
+	}
+
+	for _, c := range cases {
+		out, err := checkForCandidateShows(c.inData, c.inQuery)
+		gotErr := (err != nil)
+
+		if gotErr != c.expectErr {
+			t.Errorf("incorrect output error for '%s': expected '%t', got '%t'",
+				c.inQuery, c.expectErr, gotErr)
+		}
+
+		if out != c.expectedOut {
+			t.Errorf("incorrect output for '%s': expected '%t', got '%t'",
+				c.inQuery, c.expectedOut, out)
+		}
+	}
+}


### PR DESCRIPTION
- remove runtime from show parse since it's not provided by the API
- protect against bad schema json for tvshow object since json.Unmarshall doesn't give error for it
- fully test checkForCandidateShows function